### PR TITLE
Generalize CSS on atomic form

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ ActiveAdmin.register Page do
     actions
   end
 
-  form do |f|
+  form html: { class: "edit-atomic-content" } do |f|
     f.semantic_errors(*f.object.errors.keys)
 
     # new form

--- a/app/assets/stylesheets/atomic_cms.css.scss
+++ b/app/assets/stylesheets/atomic_cms.css.scss
@@ -24,7 +24,7 @@
 }
 
 #wrapper #active_admin_content #main_content_wrapper #main_content {
-  form#edit_page {
+  form#edit-page, form.edit-atomic-content {
     div.buttons {
       @include clearfix;
       margin: 0 0 20px;


### PR DESCRIPTION
Why?
Currently the button & form styles are coded to be applied to a 'page'
specific form, selected by id: "form#edit_page". This makes it
difficult to have multiple models in a project that are editable as
atomic CMS componenets

How?
We added another class selector to the form styles
"form.edit_atomic_content" that users can apply to their parent form
and inherit all atomic button styles.
Also, updated Readme to reflect these changes

Side Effects?
There should not be any side effects.