### PR TITLE
Fix label not present

### DIFF
--- a/app/assets/javascripts/atomic_cms.js
+++ b/app/assets/javascripts/atomic_cms.js
@@ -135,7 +135,7 @@
 
           $editor.find(':file').each(function() {
             var $input = $(this);
-            var $next = $($input.next());
+            var $next = $($input.siblings('input'));
             $input.attr('name', null).val('');
 
             return $input.on('change', function() {

--- a/app/assets/stylesheets/atomic_cms.css.scss
+++ b/app/assets/stylesheets/atomic_cms.css.scss
@@ -121,3 +121,15 @@
     }
   }
 }
+
+#edit-node-fields {
+  input[type=file] {
+    width: calc(80% - 22px);
+    font-size: 0.95em;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    padding: 8px 10px 7px;
+  }
+  label.filler {
+    color: transparent;
+  }
+}

--- a/app/views/components/_file_field.slim
+++ b/app/views/components/_file_field.slim
@@ -1,3 +1,5 @@
 span.li.string.input
+  label.label #{name.to_s.humanize}
   input.cms-field type="file"
+  label.label.filler #{name.to_s.humanize}
   input.cms-field type="text" name="#{name}" data-ng-model="preview.#{name}" value="#{value}"


### PR DESCRIPTION
Why:

So that CMS users know which fields they're editing.

This change addresses the need by:

Showing the label next to the file field and adding
a filler label for proper spacing on the text field.