### PR TITLE
Generalize form selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ ActiveAdmin.register Page do
 
     # new form
     if !f.object.persisted?
-      f.inputs 'Page Details' do
+      f.inputs "Page Details" do
         f.input :title
         f.input :path
       end
@@ -265,43 +265,45 @@ ActiveAdmin.register Page do
 
     # edit form
     else
-      div class: 'buttons' do
-        render partial: 'admin/edit_buttons'
+      div class: "buttons" do
+        render partial: "admin/edit_buttons"
         f.actions
       end
 
       columns do
         column span: 3 do
-          panel 'Draft', id: 'draft-panel' do
-            render partial: 'components/edit', locals: { f: f }
+          panel "Draft", id: "draft-panel" do
+            render partial: "components/edit", locals: { f: f }
           end
         end
 
-        column id: 'edit-node-column' do
-          div id: 'edit-page' do
-            f.inputs 'Page Details' do
+        column id: "edit-node-column" do
+          div id: "edit-page" do
+            f.inputs "Page Details" do
+            f.input :cms_type, type: :hidden,
+                               input_html: { value: "page", id: "cms_type" }
               f.input :title
               f.input :path
             end
           end
 
-          div id: 'edit-node' do
-            f.inputs 'Edit Element' do
-              div id: 'edit-node-fields'
+          div id: "edit-node" do
+            f.inputs "Edit Element" do
+              div id: "edit-node-fields"
             end
 
             f.actions do
-              li class: 'move' do
-                a 'Up', '#', class: 'button', id: 'move-node-up'
+              li class: "move" do
+                a "Up", "#", class: "button", id: "move-node-up"
               end
-              li class: 'move' do
-                a 'Down', '#', class: 'button', id: 'move-node-down'
+              li class: "move" do
+                a "Down", "#", class: "button", id: "move-node-down"
               end
-              li class: 'cancel' do
-                a 'Done', '#', class: 'button', id: 'done-edit-node'
+              li class: "cancel" do
+                a "Done", "#", class: "button", id: "done-edit-node"
               end
-              li class: 'delete' do
-                a 'Delete', '#', class: 'button', id: 'delete-node'
+              li class: "delete" do
+                a "Delete", "#", class: "button", id: "delete-node"
               end
             end
           end
@@ -311,7 +313,7 @@ ActiveAdmin.register Page do
   end
 
   show do
-    div id: 'component_preview' do
+    div id: "component_preview" do
       div page.content_render
     end
   end

--- a/app/assets/javascripts/atomic_cms.js
+++ b/app/assets/javascripts/atomic_cms.js
@@ -3,7 +3,7 @@
 
 (function() {
   'use strict';
-  var findElementIndex, page, positionEditBox, scrollTo;
+  var findElementIndex, page, positionEditBox, scrollTo, cmsType;
 
   findElementIndex = function(node) {
     var i = 0;
@@ -24,12 +24,17 @@
 
   positionEditBox = function(node) {
     var minTop, top;
-    minTop = $('#edit-page').offset().top + $('#edit-page').height() + 25;
+    minTop = $('#edit-' + cmsType()).offset().top + $('#edit-' + cmsType()).height() + 25;
     top = Math.max(minTop, $(node).offset().top);
     top -= $('#edit-node-column').offset().top;
     return $('#edit-node').css({
       top: top
     }).show();
+  };
+
+  cmsType = function(node) {
+    var cms_type = angular.element(document.querySelector('#cms_type')).val();
+    return (cms_type !== undefined) ? cms_type : 'page';
   };
 
   page = angular.module('page', ['markdown', 'ngSanitize']);
@@ -46,7 +51,7 @@
 
   page.controller('CmsCtrl', [
     '$scope', function($scope) {
-      $scope.prefix = 'page[content_object]';
+      $scope.prefix = cmsType() + '[content_object]';
       return $scope.preview = {};
     }
   ]);


### PR DESCRIPTION
### Why?
Currently the javascript only supports editing one type of model, a
"page"

### How?
Updated the angular code to look for a form field by id: cms_type
If this exists, we set the selectors to use that cms_type as a prefix,
otherwise, we stay with the default, "page"

### Side Effects?
I left "page" in there as to support the current functionality, so
hopefully there shouldn't be anything unanticipated. But, there are no
guarantees here with javascript :)