### PR TITLE
Atomic Assets Version Bump

### DIFF
--- a/atomic_cms.gemspec
+++ b/atomic_cms.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'atomic_cms'
-  s.version     = '0.1.0'
+  s.version     = '0.2.1'
   s.date        = '2015-06-19'
   s.summary     = 'Atomic CMS'
   s.description = 'Live CMS powered by atomic assets.'
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.2'
   s.add_dependency 'activeadmin', '1.0.0.pre2'
   s.add_dependency 'angularjs-rails', '~> 1.3', '< 1.4'
-  s.add_dependency 'atomic_assets', '~> 0.0.4'
+  s.add_dependency 'atomic_assets', '~> 0.1.0'
   s.add_dependency 'jquery-rails', '~> 4.0', '>= 4.0.3'
   s.add_dependency 'redcarpet', '~> 3.3'
   s.add_dependency 'slim-rails', '~> 3.0'


### PR DESCRIPTION
Why:

Atomic Assets v0.1.0 has been released.

This change addresses the need by:

Update the gemspec to require the latest version of Atomic Assets.