### PR TITLE
Bugfix resourceUrlWhitelist for amazonS3 using inline annotation

### DIFF
--- a/app/assets/javascripts/atomic_cms.js
+++ b/app/assets/javascripts/atomic_cms.js
@@ -39,12 +39,12 @@
 
   page = angular.module('page', ['markdown', 'ngSanitize']);
 
-  page.config(function($sceDelegateProvider) {
+  page.config(['$sceDelegateProvider', function($sceDelegateProvider) {
     $sceDelegateProvider.resourceUrlWhitelist([
       'self', 
       'http://s3.amazonaws.com/**'
     ]);
-  });
+  }]);
 
   page.filter('vimeo_url', [
     '$sce', function($sce) {

--- a/atomic_cms.gemspec
+++ b/atomic_cms.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'atomic_cms'
-  s.version     = '0.3.0'
+  s.version     = '0.3.1'
   s.summary     = 'Atomic CMS'
   s.description = 'Live CMS powered by atomic assets.'
   s.authors     = ['Don Humphreys', 'Spartan']


### PR DESCRIPTION
Why?
----
* Adding s3amazon to `resourceUrlWhitelist` config was not minsafe and was breaking on production

How?
----
* Convert config to use inline annotation.
* Bump gem ver to `0.3.1`