### PR TITLE
Add SSL link for s3 to resourceUrlWhitelist

### DIFF
--- a/app/assets/javascripts/atomic_cms.js
+++ b/app/assets/javascripts/atomic_cms.js
@@ -41,8 +41,9 @@
 
   page.config(['$sceDelegateProvider', function($sceDelegateProvider) {
     $sceDelegateProvider.resourceUrlWhitelist([
-      'self', 
-      'http://s3.amazonaws.com/**'
+      'self',
+      'http://s3.amazonaws.com/**',
+      'https://s3.amazonaws.com/**'
     ]);
   }]);
 

--- a/atomic_cms.gemspec
+++ b/atomic_cms.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'atomic_cms'
-  s.version     = '0.3.1'
+  s.version     = '0.3.2'
   s.summary     = 'Atomic CMS'
   s.description = 'Live CMS powered by atomic assets.'
   s.authors     = ['Don Humphreys', 'Spartan']


### PR DESCRIPTION
Why?
----
* Angular's `resourceUrlWhitelist` needs an https url in order to support production sites using SSL

How?
----
* Add additional whitelisted url for s3
* Bump gem version