### PR TITLE
Bump paperclip dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.0]
+### Updated
+- Update Paperclip dependency
+- Updated example in Readme for paperclip
+
+[0.4.0]: https://github.com/verypossible/atomic_cms/compare/v0.3.2...v0.4.0
+
 ## [0.2.5]
 ### Added
 - Changelog for tracking releases
@@ -9,4 +16,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 - Sass files to remove css to fix deprecation warnings
 
-[0.2.5]: https://github.com/spartansystems/atomic_cms/compare/v0.2.3...v0.2.5
+[0.2.5]: https://github.com/verypossible/atomic_cms/compare/v0.2.3...v0.2.5

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ intervention. Below are instructions for getting started.
 After initializing a new Rails application, or adding to an existing
 application, add the following gems to your Gemfile.
 ```ruby
-gem 'atomic_cms', github: 'spartansystems/atomic_cms'
+gem 'atomic_cms', github: 'verypossible/atomic_cms'
 gem 'devise'
 ```
 _Note: devise is optional if you do not want admin users to login._
@@ -92,7 +92,7 @@ class Application < Rails::Application
       bucket: ENV.fetch("AWS_S3_BUCKET", ""),
       access_key_id: ENV.fetch("AWS_ACCESS_KEY", ""),
       secret_access_key: ENV.fetch("AWS_SECRET", ""),
-      s3_host_name: "s3-#{ENV.fetch('AWS_REGION', '')}.amazonaws.com"
+      s3_region: ENV.fetch("AWS_REGION", ""),
     }
   }
   ...

--- a/atomic_cms.gemspec
+++ b/atomic_cms.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails', '~> 4.0', '>= 4.0.3'
   s.add_dependency 'redcarpet', '~> 3.3'
   s.add_dependency 'slim-rails', '~> 3.0'
-  s.add_dependency 'paperclip', '~> 4.3'
+  s.add_dependency 'paperclip', '~> 5.2'
 
   s.add_development_dependency 'rspec-core', '~> 3.3'
   s.add_development_dependency 'rspec-expectations', '~> 3.3'


### PR DESCRIPTION
Why:

* The older versions had security issues

This change addresses the need by:

* Upping the dep version
* Updating documentation